### PR TITLE
Fix validator.w3c.org

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -57,7 +57,7 @@
     />
 
     <link rel="stylesheet" href="styles.scss" />
-    <script type="module" src="scripts/script.ts" defer></script>
+    <script type="module" src="scripts/script.ts"></script>
   </head>
   <body>
     <main>


### PR DESCRIPTION
**Error: A `script` element with a `defer` attribute must not have a `type` attribute with the value `module`.**